### PR TITLE
Put storage of node/port data behind behaviour

### DIFF
--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -54,9 +54,9 @@ start_link(Args) ->
 %% ------------------------------------------------------------------
 
 init([]) ->
-    init([erlpmd]);
-init([Store]) ->
-    {ok, S0} = Store:init(),
+    init([erlpmd, []]);
+init([Store, Args]) ->
+    {ok, S0} = Store:init(Args),
 	error_logger:info_msg("ErlPMD: started.~n"),
 	self() ! notify_init,
 	{ok, RelaxedCommandCheck} = application:get_env(erlpmd, relaxed_command_check),

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -107,7 +107,7 @@ handle_cast({{msg, From},<<$n>>, _Fd, Ip, Port}, State) ->
 	error_logger:info_msg("ErlPMD: name(s) request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
     {ok, NodeInfos} = Store:names(S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || {X, Y} <- NodeInfos])),
-    %% TODO This looks like a hard-coded port number...
+    %% TODO This is the WRONG PORT
 	gen_server:cast(From, {msg, <<Port:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};
@@ -117,7 +117,7 @@ handle_cast({{msg, From},<<$d>>, _Fd, Ip, Port}, State) ->
 	error_logger:info_msg("ErlPMD: dump request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
     {ok, NodeDump} = Store:dump(77, S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("active name     ~s at port ~p, fd = ~p ~n", [X, Y, F]) || {X, Y, F} <- NodeDump])),
-    %% TODO Again this looks suspiciously like a hard-coded port no
+    %% TODO This is the WRONG PORT
 	gen_server:cast(From, {msg, <<Port:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -24,8 +24,6 @@
 -module(erlpmd).
 -behaviour(gen_server).
 
--include_lib("kernel/src/erl_epmd.hrl").
-
 %% ------------------------------------------------------------------
 %% API Function Exports
 %% ------------------------------------------------------------------
@@ -61,7 +59,7 @@ handle_call(Request, From, State) ->
 	error_logger:warning_msg("ErlPMD: strange call: ~p from: ~p.~n", [Request, From]),
 	{reply, ok, State}.
 
-handle_cast({{msg,From},<<?EPMD_ALIVE2_REQ, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16, NLen:16, Rest/binary>>, Fd, Ip, Port}, State) ->
+handle_cast({{msg,From},<<$x, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16, NLen:16, Rest/binary>>, Fd, Ip, Port}, State) ->
 	<<NodeName:NLen/binary, _ELen:16, Extra/binary>> = Rest,
 	Creation = random:uniform(3),
 	error_logger:info_msg(
@@ -70,16 +68,16 @@ handle_cast({{msg,From},<<?EPMD_ALIVE2_REQ, PortNo:16, NodeType:8, Proto:8, HiVe
 	case ets:lookup(erlpmd, NodeName) of
 		[] ->
 			ets:insert_new(erlpmd, {NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra, Creation, Fd}}),
-			gen_server:cast(From, {msg, <<?EPMD_ALIVE2_RESP, 0:8, Creation:16>>, Ip, Port});
+			gen_server:cast(From, {msg, <<$y, 0:8, Creation:16>>, Ip, Port});
 		_ ->
 			% Already registered - reply with error
 			error_logger:error_msg("ErlPMD: ~s 'name' is already registered.~n", [NodeName]),
-			gen_server:cast(From, {msg, <<?EPMD_ALIVE2_RESP, 1:8, 99:16>>, Ip, Port})
+			gen_server:cast(From, {msg, <<$y, 1:8, 99:16>>, Ip, Port})
 	end,
 	{noreply, State};
 
 
-handle_cast({{msg, From},<<?EPMD_PORT_PLEASE2_REQ, NodeName/binary>>, _Fd, Ip, Port}, State) ->
+handle_cast({{msg, From},<<$z, NodeName/binary>>, _Fd, Ip, Port}, State) ->
 	error_logger:info_msg("ErlPMD: port ~s request from ~s:~p.~n", [NodeName, inet_parse:ntoa(Ip), Port]),
 	case ets:lookup(erlpmd, NodeName) of
 		[] ->
@@ -87,33 +85,33 @@ handle_cast({{msg, From},<<?EPMD_PORT_PLEASE2_REQ, NodeName/binary>>, _Fd, Ip, P
 		[{NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra, _, _}}] ->
 			NLen = size(NodeName),
 			ELen = size(Extra),
-			gen_server:cast(From, {msg, <<?EPMD_PORT2_RESP, 0:8, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16, NLen:16, NodeName:NLen/binary, ELen:16, Extra:ELen/binary>>, Ip, Port})
+			gen_server:cast(From, {msg, <<$w, 0:8, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16, NLen:16, NodeName:NLen/binary, ELen:16, Extra:ELen/binary>>, Ip, Port})
 	end,
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};
 
-handle_cast({{msg, From},<<?EPMD_NAMES>>, _Fd, Ip, Port}, State) ->
+handle_cast({{msg, From},<<$n>>, _Fd, Ip, Port}, State) ->
 	error_logger:info_msg("ErlPMD: name(s) request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || [X, Y] <- ets:match(erlpmd, {'$1', {'$2', 77, '_', '_', '_', '_', '_', '_'}})])),
 	gen_server:cast(From, {msg, <<4369:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};
 
-handle_cast({{msg, From},<<?EPMD_DUMP>>, _Fd, Ip, Port}, State) ->
+handle_cast({{msg, From},<<$d>>, _Fd, Ip, Port}, State) ->
 	error_logger:info_msg("ErlPMD: dump request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("active name     ~s at port ~p, fd = ~p ~n", [X, Y, F]) || [X, Y, F] <- ets:match(erlpmd, {'$1', {'$2', 77, '_', '_', '_', '_', '_', '$3'}})])),
 	gen_server:cast(From, {msg, <<4369:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};
 
-handle_cast({{msg, From},<<?EPMD_KILL>>, _Fd, Ip, Port}, true) ->
+handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, true) ->
 	% Allow stop command in case we're running with -relaxed_command_check
 	% w/o checking for actually available nodes
 	error_logger:info_msg("ErlPMD: kill request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
 	gen_server:cast(From, {msg, <<"OK">>, Ip, Port}),
 	gen_server:cast(From, stop),
 	{stop, normal, true};
-handle_cast({{msg, From},<<?EPMD_KILL>>, _Fd, Ip, Port}, false) ->
+handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, false) ->
 	error_logger:info_msg("ErlPMD: kill request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
 	gen_server:cast(From, {msg, <<"OK">>, Ip, Port}),
 	case ets:match(erlpmd, {'_', {'_', '_', '_', '_', '_', '_', '_', '_'}}) of
@@ -126,12 +124,12 @@ handle_cast({{msg, From},<<?EPMD_KILL>>, _Fd, Ip, Port}, false) ->
 			{noreply, false}
 	end;
 
-handle_cast({{msg, From},<<?EPMD_STOP, NodeName/binary>>, _Fd, Ip, Port}, false) ->
+handle_cast({{msg, From},<<$s, NodeName/binary>>, _Fd, Ip, Port}, false) ->
 	% Ignore stop command in case we're running w/o -relaxed_command_check
 	error_logger:info_msg("ErlPMD: '~s' stop request from ~s:~p. (IGNORED)~n", [NodeName, inet_parse:ntoa(Ip), Port]),
 	gen_server:cast(From, {msg, <<"STOPPED">>, Ip, Port}),
 	{noreply, false};
-handle_cast({{msg, From},<<?EPMD_STOP, NodeName/binary>>, _Fd, Ip, Port}, true) ->
+handle_cast({{msg, From},<<$s, NodeName/binary>>, _Fd, Ip, Port}, true) ->
 	error_logger:info_msg("ErlPMD: '~s' stop request from ~s:~p.~n", [NodeName, inet_parse:ntoa(Ip), Port]),
 	case ets:match(erlpmd, {NodeName, {'_', '_', '_', '_', '_', '_', '_', '_'}}) of
 		[] ->

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -108,7 +108,7 @@ handle_cast({{msg, From},<<$n>>, _Fd, Ip, Port}, State) ->
     {ok, NodeInfos} = Store:names(S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || [X, Y] <- NodeInfos])),
     %% TODO This looks like a hard-coded port number...
-	gen_server:cast(From, {msg, <<4369:32, Nodes/binary>>, Ip, Port}),
+	gen_server:cast(From, {msg, <<Port:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};
 
@@ -118,7 +118,7 @@ handle_cast({{msg, From},<<$d>>, _Fd, Ip, Port}, State) ->
     {ok, NodeDump} = Store:dump(S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("active name     ~s at port ~p, fd = ~p ~n", [X, Y, F]) || {X, Y, F} <- NodeDump])),
     %% TODO Again this looks suspiciously like a hard-coded port no
-	gen_server:cast(From, {msg, <<4369:32, Nodes/binary>>, Ip, Port}),
+	gen_server:cast(From, {msg, <<Port:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};
 

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -106,7 +106,7 @@ handle_cast({{msg, From},<<$n>>, _Fd, Ip, Port}, State) ->
     #state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: name(s) request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
     {ok, NodeInfos} = Store:names(S0),
-	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || [X, Y] <- NodeInfos])),
+	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || {X, Y} <- NodeInfos])),
     %% TODO This looks like a hard-coded port number...
 	gen_server:cast(From, {msg, <<Port:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -115,7 +115,7 @@ handle_cast({{msg, From},<<$n>>, _Fd, Ip, Port}, State) ->
 handle_cast({{msg, From},<<$d>>, _Fd, Ip, Port}, State) ->
     #state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: dump request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
-    {ok, NodeDump} = Store:dump(S0),
+    {ok, NodeDump} = Store:dump(77, S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("active name     ~s at port ~p, fd = ~p ~n", [X, Y, F]) || {X, Y, F} <- NodeDump])),
     %% TODO Again this looks suspiciously like a hard-coded port no
 	gen_server:cast(From, {msg, <<Port:32, Nodes/binary>>, Ip, Port}),

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -37,6 +37,11 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
+-record(state,
+        {
+         store :: {atom(), any()},
+         relaxed_cmd :: boolean()
+        }).
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
@@ -49,11 +54,15 @@ start_link(Args) ->
 %% ------------------------------------------------------------------
 
 init(_Args) ->
-	erlpmd = ets:new(erlpmd, [public, named_table]),
+	Store = erlpmd_ets:init(),
 	error_logger:info_msg("ErlPMD: started.~n"),
 	self() ! notify_init,
 	{ok, RelaxedCommandCheck} = application:get_env(erlpmd, relaxed_command_check),
-	{ok, RelaxedCommandCheck}.
+    State = #state{
+       store = {erlpmd_ets, Store},
+       relaxed_cmd = RelaxedCommandCheck
+      },
+	{ok, State}.
 
 handle_call(Request, From, State) ->
 	error_logger:warning_msg("ErlPMD: strange call: ~p from: ~p.~n", [Request, From]),
@@ -61,15 +70,15 @@ handle_call(Request, From, State) ->
 
 handle_cast({{msg,From},<<$x, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16, NLen:16, Rest/binary>>, Fd, Ip, Port}, State) ->
 	<<NodeName:NLen/binary, _ELen:16, Extra/binary>> = Rest,
+    #state{store = {Store, S0}} = State,
 	Creation = random:uniform(3),
 	error_logger:info_msg(
 		"ErlPMD: alive request from ~s:~b PortNo: ~b, NodeType: ~b, Proto: ~b, HiVer: ~b, LoVer: ~b, NodeName: '~s', Extra: ~p, Creation: ~b.~n",
 		[inet_parse:ntoa(Ip), Port, PortNo, NodeType, Proto, HiVer, LoVer, NodeName, Extra, Creation]),
-	case ets:lookup(erlpmd, NodeName) of
-		[] ->
-			ets:insert_new(erlpmd, {NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra, Creation, Fd}}),
+    case Store:register_node(NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra}, Fd, Creation, S0) of
+		ok ->
 			gen_server:cast(From, {msg, <<$y, 0:8, Creation:16>>, Ip, Port});
-		_ ->
+        {error, registered} ->
 			% Already registered - reply with error
 			error_logger:error_msg("ErlPMD: ~s 'name' is already registered.~n", [NodeName]),
 			gen_server:cast(From, {msg, <<$y, 1:8, 99:16>>, Ip, Port})
@@ -78,11 +87,12 @@ handle_cast({{msg,From},<<$x, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16
 
 
 handle_cast({{msg, From},<<$z, NodeName/binary>>, _Fd, Ip, Port}, State) ->
+    #state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: port ~s request from ~s:~p.~n", [NodeName, inet_parse:ntoa(Ip), Port]),
-	case ets:lookup(erlpmd, NodeName) of
-		[] ->
+    case Store:node_port(NodeName, S0) of
+        {error, not_found} ->
 			gen_server:cast(From, {msg, <<$w, 1:8>>, Ip, Port});
-		[{NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra, _, _}}] ->
+		{NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra, _, _}} ->
 			NLen = size(NodeName),
 			ELen = size(Extra),
 			gen_server:cast(From, {msg, <<$w, 0:8, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16, NLen:16, NodeName:NLen/binary, ELen:16, Extra:ELen/binary>>, Ip, Port})
@@ -91,62 +101,69 @@ handle_cast({{msg, From},<<$z, NodeName/binary>>, _Fd, Ip, Port}, State) ->
 	{noreply, State};
 
 handle_cast({{msg, From},<<$n>>, _Fd, Ip, Port}, State) ->
+    #state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: name(s) request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
-	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || [X, Y] <- ets:match(erlpmd, {'$1', {'$2', 77, '_', '_', '_', '_', '_', '_'}})])),
+    NodeInfos = Store:names(S0),
+	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || [X, Y] <- NodeInfos])),
+    %% TODO This looks like a hard-coded port number...
 	gen_server:cast(From, {msg, <<4369:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};
 
 handle_cast({{msg, From},<<$d>>, _Fd, Ip, Port}, State) ->
+    #state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: dump request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
-	Nodes = list_to_binary(lists:flatten([ io_lib:format("active name     ~s at port ~p, fd = ~p ~n", [X, Y, F]) || [X, Y, F] <- ets:match(erlpmd, {'$1', {'$2', 77, '_', '_', '_', '_', '_', '$3'}})])),
+    NodeDump = Store:dump(S0),
+	Nodes = list_to_binary(lists:flatten([ io_lib:format("active name     ~s at port ~p, fd = ~p ~n", [X, Y, F]) || {X, Y, F} <- NodeDump])),
+    %% TODO Again this looks suspiciously like a hard-coded port no
 	gen_server:cast(From, {msg, <<4369:32, Nodes/binary>>, Ip, Port}),
 	gen_server:cast(From, {close, Ip, Port}),
 	{noreply, State};
 
-handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, true) ->
+handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, #state{relaxed_cmd=true}=State) ->
 	% Allow stop command in case we're running with -relaxed_command_check
 	% w/o checking for actually available nodes
 	error_logger:info_msg("ErlPMD: kill request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
 	gen_server:cast(From, {msg, <<"OK">>, Ip, Port}),
 	gen_server:cast(From, stop),
-	{stop, normal, true};
-handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, false) ->
+	{stop, normal, State};
+handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, #state{relaxed_cmd=false}=State) ->
+    #state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: kill request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
 	gen_server:cast(From, {msg, <<"OK">>, Ip, Port}),
-	case ets:match(erlpmd, {'_', {'_', '_', '_', '_', '_', '_', '_', '_'}}) of
-		[] ->
+    %% TODO This is ETS specific knowledge '_'
+    case Store:dump(all, S0) of
+        {ok, []} ->
 			% No live nodes - we may exit now
 			gen_server:cast(From, stop),
-			{stop, normal, false};
-		_ ->
+			{stop, normal, State};
+        {ok, _} ->
 			% Disallow killing witl live nodes
-			{noreply, false}
+			{noreply, State}
 	end;
 
-handle_cast({{msg, From},<<$s, NodeName/binary>>, _Fd, Ip, Port}, false) ->
+handle_cast({{msg, From},<<$s, NodeName/binary>>, _Fd, Ip, Port}, #state{relaxed_cmd=false}=State) ->
 	% Ignore stop command in case we're running w/o -relaxed_command_check
 	error_logger:info_msg("ErlPMD: '~s' stop request from ~s:~p. (IGNORED)~n", [NodeName, inet_parse:ntoa(Ip), Port]),
 	gen_server:cast(From, {msg, <<"STOPPED">>, Ip, Port}),
-	{noreply, false};
-handle_cast({{msg, From},<<$s, NodeName/binary>>, _Fd, Ip, Port}, true) ->
+	{noreply, State};
+handle_cast({{msg, From},<<$s, NodeName/binary>>, _Fd, Ip, Port}, #state{relaxed_cmd=true}=State) ->
+    #state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: '~s' stop request from ~s:~p.~n", [NodeName, inet_parse:ntoa(Ip), Port]),
-	case ets:match(erlpmd, {NodeName, {'_', '_', '_', '_', '_', '_', '_', '_'}}) of
-		[] ->
+    case Store:dump('_', S0) of
+        {ok, []} ->
 			gen_server:cast(From, {msg, <<"NOEXIST">>, Ip, Port});
-		_ ->
-			ets:delete(erlpmd, NodeName),
+        {ok, _} ->
+            Store:remove_node(NodeName, S0),
 			gen_server:cast(From, {msg, <<"STOPPED">>, Ip, Port})
 	end,
 	gen_server:cast(From, {close, Ip, Port}),
-	{noreply, true};
+	{noreply, State};
 
 handle_cast({{close, _From}, Fd}, State) ->
+    #state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: closed connection: ~p.~n", [Fd]),
-	case ets:match(erlpmd, {'$1', {'_', '_', '_', '_', '_', '_', '_', Fd}}) of
-		[[NodeName]] -> ets:delete(erlpmd, NodeName);
-		_ -> ok
-	end,
+    Store:node_stopped(Fd, S0),
 	{noreply, State};
 
 handle_cast(Msg, State) ->

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -37,6 +37,8 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 		 terminate/2, code_change/3]).
 
+-include("erlpmd.hrl").
+
 -record(state,
 		{
 		 store :: {atom(), any()},
@@ -117,7 +119,7 @@ handle_cast({{msg, From},<<$z, NodeName/binary>>, _Fd, Ip, Port}, State) ->
 handle_cast({{msg, From},<<$n>>, Fd, Ip, Port}, State) ->
 	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: name(s) request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
-	{ok, NodeInfos} = Store:names(S0),
+	{ok, NodeInfos} = Store:names(?NORMAL_NODE, S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || {X, Y} <- NodeInfos])),
 	%% TODO Validate that this will work if LISTEN_FDS is set (if that's even a thing any more?)
 	{ok, LocalPort} = inet:port(Fd),
@@ -128,7 +130,7 @@ handle_cast({{msg, From},<<$n>>, Fd, Ip, Port}, State) ->
 handle_cast({{msg, From},<<$d>>, Fd, Ip, Port}, State) ->
 	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: dump request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
-	{ok, NodeDump} = Store:dump(77, S0),
+	{ok, NodeDump} = Store:dump(?NORMAL_NODE, S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("active name     ~s at port ~p, fd = ~p ~n", [X, Y, F]) || {X, Y, F} <- NodeDump])),
 	%% TODO Validate that this will work if LISTEN_FDS is set (if that's even a thing any more?)
 	{ok, LocalPort} = inet:port(Fd),

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -147,7 +147,6 @@ handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, #state{relaxed_cmd=false}=State
 	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: kill request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
 	msg(From, <<"OK">>, Ip, Port),
-	%% TODO This is ETS specific knowledge '_'
 	case Store:dump(all, S0) of
 		{ok, []} ->
 			% No live nodes - we may exit now

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -35,13 +35,13 @@
 %% ------------------------------------------------------------------
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+		 terminate/2, code_change/3]).
 
 -record(state,
-        {
-         store :: {atom(), any()},
-         relaxed_cmd :: boolean()
-        }).
+		{
+		 store :: {atom(), any()},
+		 relaxed_cmd :: boolean()
+		}).
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
@@ -50,29 +50,29 @@ start_link(Args) ->
 	gen_server:start_link({local, ?MODULE}, ?MODULE, Args, []).
 
 msg(Pid, Msg, Ip, Port) when is_binary(Msg) ->
-    gen_server:cast(Pid, {msg, Msg, Ip, Port}).
+	gen_server:cast(Pid, {msg, Msg, Ip, Port}).
 
 close(Pid, Ip, Port) ->
-    gen_server:cast(Pid, {close, Ip, Port}).
+	gen_server:cast(Pid, {close, Ip, Port}).
 
 stop(Pid) ->
-    gen_server:cast(Pid, stop).
+	gen_server:cast(Pid, stop).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 
 init([]) ->
-    init([erlpmd, []]);
+	init([erlpmd, []]);
 init([Store, Args]) ->
-    {ok, S0} = Store:init(Args),
+	{ok, S0} = Store:init(Args),
 	error_logger:info_msg("ErlPMD: started.~n"),
 	self() ! notify_init,
 	{ok, RelaxedCommandCheck} = application:get_env(erlpmd, relaxed_command_check),
-    State = #state{
-       store = {Store, S0},
-       relaxed_cmd = RelaxedCommandCheck
-      },
+	State = #state{
+		store = {Store, S0},
+		relaxed_cmd = RelaxedCommandCheck
+	},
 	{ok, State}.
 
 handle_call(Request, From, State) ->
@@ -81,33 +81,32 @@ handle_call(Request, From, State) ->
 
 handle_cast({{msg,From},<<$x, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16, NLen:16, Rest/binary>>, Fd, Ip, Port}, State) ->
 	<<NodeName:NLen/binary, _ELen:16, Extra/binary>> = Rest,
-    #state{store = {Store, S0}} = State,
+	#state{store = {Store, S0}} = State,
 	Creation = random:uniform(3),
 	error_logger:info_msg(
 		"ErlPMD: alive request from ~s:~b PortNo: ~b, NodeType: ~b, Proto: ~b, HiVer: ~b, LoVer: ~b, NodeName: '~s', Extra: ~p, Creation: ~b.~n",
 		[inet_parse:ntoa(Ip), Port, PortNo, NodeType, Proto, HiVer, LoVer, NodeName, Extra, Creation]),
-    case Store:register_node(NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra}, Fd, Creation, S0) of
+	case Store:register_node(NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra}, Fd, Creation, S0) of
 		ok ->
 			msg(From, <<$y, 0:8, Creation:16>>, Ip, Port),
-            {noreply, State};
-        {ok, S1} ->
-            msg(From, <<$y, 0:8, Creation:16>>, Ip, Port),
-            {noreply, State#state{store={Store, S1}}};
-        {error, registered} ->
+			{noreply, State};
+		{ok, S1} ->
+			msg(From, <<$y, 0:8, Creation:16>>, Ip, Port),
+			{noreply, State#state{store={Store, S1}}};
+		{error, registered} ->
 			% Already registered - reply with error
 			error_logger:error_msg("ErlPMD: ~s 'name' is already registered.~n", [NodeName]),
 			msg(From, <<$y, 1:8, 99:16>>, Ip, Port),
-            {noreply, State}
-    end;
-
+			{noreply, State}
+	end;
 
 handle_cast({{msg, From},<<$z, NodeName/binary>>, _Fd, Ip, Port}, State) ->
-    #state{store = {Store, S0}} = State,
+	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: port ~s request from ~s:~p.~n", [NodeName, inet_parse:ntoa(Ip), Port]),
-    case Store:node_port(NodeName, S0) of
-        {error, not_found} ->
+	case Store:node_port(NodeName, S0) of
+		{error, not_found} ->
 			msg(From, <<$w, 1:8>>, Ip, Port);
-        {ok, {NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra, _, _}}} ->
+		{ok, {NodeName, {PortNo, NodeType, Proto, HiVer, LoVer, Extra, _, _}}} ->
 			NLen = size(NodeName),
 			ELen = size(Extra),
 			msg(From, <<$w, 0:8, PortNo:16, NodeType:8, Proto:8, HiVer:16, LoVer:16, NLen:16, NodeName:NLen/binary, ELen:16, Extra:ELen/binary>>, Ip, Port)
@@ -116,23 +115,23 @@ handle_cast({{msg, From},<<$z, NodeName/binary>>, _Fd, Ip, Port}, State) ->
 	{noreply, State};
 
 handle_cast({{msg, From},<<$n>>, Fd, Ip, Port}, State) ->
-    #state{store = {Store, S0}} = State,
+	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: name(s) request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
-    {ok, NodeInfos} = Store:names(S0),
+	{ok, NodeInfos} = Store:names(S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("name ~s at port ~p~n", [X, Y]) || {X, Y} <- NodeInfos])),
-    %% TODO Validate that this will work if LISTEN_FDS is set (if that's even a thing any more?)
-    {ok, LocalPort} = inet:port(Fd),
+	%% TODO Validate that this will work if LISTEN_FDS is set (if that's even a thing any more?)
+	{ok, LocalPort} = inet:port(Fd),
 	msg(From, <<LocalPort:32, Nodes/binary>>, Ip, Port),
 	close(From, Ip, Port),
 	{noreply, State};
 
 handle_cast({{msg, From},<<$d>>, Fd, Ip, Port}, State) ->
-    #state{store = {Store, S0}} = State,
+	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: dump request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
-    {ok, NodeDump} = Store:dump(77, S0),
+	{ok, NodeDump} = Store:dump(77, S0),
 	Nodes = list_to_binary(lists:flatten([ io_lib:format("active name     ~s at port ~p, fd = ~p ~n", [X, Y, F]) || {X, Y, F} <- NodeDump])),
-    %% TODO Validate that this will work if LISTEN_FDS is set (if that's even a thing any more?)
-    {ok, LocalPort} = inet:port(Fd),
+	%% TODO Validate that this will work if LISTEN_FDS is set (if that's even a thing any more?)
+	{ok, LocalPort} = inet:port(Fd),
 	msg(From, <<LocalPort:32, Nodes/binary>>, Ip, Port),
 	close(From, Ip, Port),
 	{noreply, State};
@@ -145,16 +144,16 @@ handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, #state{relaxed_cmd=true}=State)
 	stop(From),
 	{stop, normal, State};
 handle_cast({{msg, From},<<$k>>, _Fd, Ip, Port}, #state{relaxed_cmd=false}=State) ->
-    #state{store = {Store, S0}} = State,
+	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: kill request from ~s:~p.~n", [inet_parse:ntoa(Ip), Port]),
 	msg(From, <<"OK">>, Ip, Port),
-    %% TODO This is ETS specific knowledge '_'
-    case Store:dump(all, S0) of
-        {ok, []} ->
+	%% TODO This is ETS specific knowledge '_'
+	case Store:dump(all, S0) of
+		{ok, []} ->
 			% No live nodes - we may exit now
 			stop(From),
 			{stop, normal, State};
-        {ok, _} ->
+		{ok, _} ->
 			% Disallow killing with live nodes
 			{noreply, State}
 	end;
@@ -165,30 +164,30 @@ handle_cast({{msg, From},<<$s, NodeName/binary>>, _Fd, Ip, Port}, #state{relaxed
 	msg(From, <<"STOPPED">>, Ip, Port),
 	{noreply, State};
 handle_cast({{msg, From},<<$s, NodeName/binary>>, _Fd, Ip, Port}, #state{relaxed_cmd=true}=State) ->
-    #state{store = {Store, S0}} = State,
+	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: '~s' stop request from ~s:~p.~n", [NodeName, inet_parse:ntoa(Ip), Port]),
-    State1 =
-        case Store:remove_node(NodeName, S0) of
-            ok ->
-                msg(From, <<"STOPPED">>, Ip, Port),
-                State;
-            {ok, S1} ->
-                msg(From, <<"STOPPED">>, Ip, Port),
-                State#state{store={Store, S1}};
-            {error, no_node} ->
-                msg(From, <<"NOEXIST">>, Ip, Port),
-                State
-        end,
-    close(From, Ip, Port),
-    {noreply, State1};
+	State1 =
+		case Store:remove_node(NodeName, S0) of
+			ok ->
+				msg(From, <<"STOPPED">>, Ip, Port),
+				State;
+			{ok, S1} ->
+				msg(From, <<"STOPPED">>, Ip, Port),
+				State#state{store={Store, S1}};
+			{error, no_node} ->
+				msg(From, <<"NOEXIST">>, Ip, Port),
+				State
+		end,
+	close(From, Ip, Port),
+	{noreply, State1};
 
 handle_cast({{close, _From}, Fd}, State) ->
-    #state{store = {Store, S0}} = State,
+	#state{store = {Store, S0}} = State,
 	error_logger:info_msg("ErlPMD: closed connection: ~p.~n", [Fd]),
-    case Store:node_stopped(Fd, S0) of
-        ok -> {noreply, State};
-        {ok, S1} -> {noreply, State#state{store={Store, S1}}}
-    end;
+	case Store:node_stopped(Fd, S0) of
+		ok -> {noreply, State};
+		{ok, S1} -> {noreply, State#state{store={Store, S1}}}
+	end;
 
 handle_cast(Msg, State) ->
 	error_logger:warning_msg("ErlPMD: strange cast: ~p.~n", [Msg]),

--- a/src/erlpmd.erl
+++ b/src/erlpmd.erl
@@ -53,13 +53,15 @@ start_link(Args) ->
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 
-init(_Args) ->
-	Store = erlpmd_ets:init(),
+init([]) ->
+    init([erlpmd]);
+init([Store]) ->
+	S0 = Store:init(),
 	error_logger:info_msg("ErlPMD: started.~n"),
 	self() ! notify_init,
 	{ok, RelaxedCommandCheck} = application:get_env(erlpmd, relaxed_command_check),
     State = #state{
-       store = {erlpmd_ets, Store},
+       store = {Store, S0},
        relaxed_cmd = RelaxedCommandCheck
       },
 	{ok, State}.

--- a/src/erlpmd.hrl
+++ b/src/erlpmd.hrl
@@ -1,0 +1,2 @@
+-define(NORMAL_NODE, 77).
+-define(HIDDEN_NODE, 72).

--- a/src/erlpmd_ets.erl
+++ b/src/erlpmd_ets.erl
@@ -4,45 +4,45 @@
 % Callback module to store data in ETS
 
 -export([
-         init/1,
-         register_node/5,
-         node_port/2,
-         names/1,
-         dump/2,
-         node_stopped/2,
-         remove_node/2
-        ]).
+		 init/1,
+		 register_node/5,
+		 node_port/2,
+		 names/1,
+		 dump/2,
+		 node_stopped/2,
+		 remove_node/2
+		]).
 
 init([]) ->
-    erlpmd = ets:new(erlpmd, [public, named_table]),
-    {ok, erlpmd}.
+	erlpmd = ets:new(erlpmd, [public, named_table]),
+	{ok, erlpmd}.
 
 register_node(NodeName, {PortNo, NodeType, Protocol, HighestVersion, LowestVersion, Extra}, Fd, Creation, erlpmd) ->
-    case ets:lookup(erlpmd, NodeName) of
-        [] ->
-            ets:insert_new(erlpmd, {NodeName, {PortNo, NodeType, Protocol, HighestVersion, LowestVersion, Extra, Fd, Creation}}),
-            ok;
-        _ -> {error, registered}
-    end.
+	case ets:lookup(erlpmd, NodeName) of
+		[] ->
+			ets:insert_new(erlpmd, {NodeName, {PortNo, NodeType, Protocol, HighestVersion, LowestVersion, Extra, Fd, Creation}}),
+			ok;
+		_ -> {error, registered}
+	end.
 
 node_port(NodeName, erlpmd) ->
 	case ets:lookup(erlpmd, NodeName) of
 		[] ->
-            {error, not_found};
-        %% TODO Should probably really validate the returned structure here
+			{error, not_found};
+		%% TODO Should probably really validate the returned structure here
 		[{NodeName, _}=NodeInfo] ->
-            {ok, NodeInfo}
-    end.
+			{ok, NodeInfo}
+	end.
 
 names(erlpmd) ->
-    {ok, [{Name, Port}
-          || [Name, Port] <- ets:match(erlpmd, {'$1', {'$2', 77, '_', '_', '_', '_', '_', '_'}})]}.
+	{ok, [{Name, Port}
+		  || [Name, Port] <- ets:match(erlpmd, {'$1', {'$2', 77, '_', '_', '_', '_', '_', '_'}})]}.
 
 dump(all, erlpmd) -> dump('_', erlpmd);
 dump(NodeType, erlpmd) ->
-    {ok, [{Name, Port, Fd}
-          || [Name, Port, Fd] <- ets:match(erlpmd,
-                                           {'$1', {'$2', NodeType, '_', '_', '_', '_', '$3', '_'}})]}.
+	{ok, [{Name, Port, Fd}
+		  || [Name, Port, Fd] <- ets:match(erlpmd,
+										   {'$1', {'$2', NodeType, '_', '_', '_', '_', '$3', '_'}})]}.
 
 node_stopped(Fd, erlpmd) ->
 	case ets:match(erlpmd, {'$1', {'_', '_', '_', '_', '_', '_', '_', Fd}}) of
@@ -51,4 +51,4 @@ node_stopped(Fd, erlpmd) ->
 	end.
 
 remove_node(NodeName, erlpmd) ->
-    ets:delete(NodeName).
+	ets:delete(NodeName).

--- a/src/erlpmd_ets.erl
+++ b/src/erlpmd_ets.erl
@@ -7,7 +7,7 @@
 		 init/1,
 		 register_node/5,
 		 node_port/2,
-		 names/1,
+		 names/2,
 		 dump/2,
 		 node_stopped/2,
 		 remove_node/2
@@ -34,9 +34,9 @@ node_port(NodeName, erlpmd) ->
 			{ok, NodeInfo}
 	end.
 
-names(erlpmd) ->
+names(Type, erlpmd) ->
 	{ok, [{Name, Port}
-		  || [Name, Port] <- ets:match(erlpmd, {'$1', {'$2', 77, '_', '_', '_', '_', '_', '_'}})]}.
+		  || [Name, Port] <- ets:match(erlpmd, {'$1', {'$2', Type, '_', '_', '_', '_', '_', '_'}})]}.
 
 dump(all, erlpmd) -> dump('_', erlpmd);
 dump(NodeType, erlpmd) ->

--- a/src/erlpmd_ets.erl
+++ b/src/erlpmd_ets.erl
@@ -45,11 +45,11 @@ dump(NodeType, erlpmd) ->
 										   {'$1', {'$2', NodeType, '_', '_', '_', '_', '$3', '_'}})]}.
 
 node_stopped(Fd, erlpmd) ->
-	case ets:match(erlpmd, {'$1', {'_', '_', '_', '_', '_', '_', '_', Fd}}) of
+	case ets:match(erlpmd, {'$1', {'_', '_', '_', '_', '_', '_', Fd, '_'}}) of
 		[[NodeName]] -> remove_node(NodeName, erlpmd);
 		_ -> ok
 	end.
 
 remove_node(NodeName, erlpmd) ->
-	true = ets:delete(NodeName),
+	true = ets:delete(erlpmd, NodeName),
 	{ok, erlpmd}.

--- a/src/erlpmd_ets.erl
+++ b/src/erlpmd_ets.erl
@@ -51,4 +51,5 @@ node_stopped(Fd, erlpmd) ->
 	end.
 
 remove_node(NodeName, erlpmd) ->
-	ets:delete(NodeName).
+	true = ets:delete(NodeName),
+	{ok, erlpmd}.

--- a/src/erlpmd_ets.erl
+++ b/src/erlpmd_ets.erl
@@ -1,0 +1,54 @@
+-module(erlpmd_ets).
+
+-behaviour(erlpmd_store).
+% Callback module to store data in ETS
+
+-export([
+         init/0,
+         register_node/5,
+         node_port/2,
+         names/1,
+         dump/2,
+         node_stopped/2,
+         remove_node/2
+        ]).
+
+init() ->
+    erlpmd = ets:new(erlpmd, [public, named_table]),
+    {ok, erlpmd}.
+
+register_node(NodeName, {PortNo, NodeType, Protocol, HighestVersion, LowestVersion, Extra}, Fd, Creation, erlpmd) ->
+    case ets:lookup(erlpmd, NodeName) of
+        [] ->
+            ets:insert_new(erlpmd, {NodeName, {PortNo, NodeType, Protocol, HighestVersion, LowestVersion, Extra, Fd, Creation}}),
+            ok;
+        _ -> {error, registered}
+    end.
+
+node_port(NodeName, erlpmd) ->
+	case ets:lookup(erlpmd, NodeName) of
+		[] ->
+            {error, not_found};
+        %% TODO Should probably really validate the returned structure here
+		[{NodeName, _}=NodeInfo] ->
+            {ok, NodeInfo}
+    end.
+
+names(erlpmd) ->
+    {ok, [{Name, Port}
+          || [Name, Port] <- ets:match(erlpmd, {'$1', {'$2', 77, '_', '_', '_', '_', '_', '_'}})]}.
+
+dump(all, erlpmd) -> dump('_', erlpmd);
+dump(NodeType, erlpmd) ->
+    {ok, [{Name, Port, Fd}
+          || [Name, Port, Fd] <- ets:match(erlpmd,
+                                           {'$1', {'$2', NodeType, '_', '_', '_', '_', '$3', '_'}})]}.
+
+node_stopped(Fd, erlpmd) ->
+	case ets:match(erlpmd, {'$1', {'_', '_', '_', '_', '_', '_', '_', Fd}}) of
+		[[NodeName]] -> remove_node(NodeName, erlpmd);
+		_ -> ok
+	end.
+
+remove_node(NodeName, erlpmd) ->
+    ets:delete(NodeName).

--- a/src/erlpmd_ets.erl
+++ b/src/erlpmd_ets.erl
@@ -4,7 +4,7 @@
 % Callback module to store data in ETS
 
 -export([
-         init/0,
+         init/1,
          register_node/5,
          node_port/2,
          names/1,
@@ -13,7 +13,7 @@
          remove_node/2
         ]).
 
-init() ->
+init([]) ->
     erlpmd = ets:new(erlpmd, [public, named_table]),
     {ok, erlpmd}.
 

--- a/src/erlpmd_store.erl
+++ b/src/erlpmd_store.erl
@@ -6,14 +6,14 @@
 -callback register_node(
 			NodeName :: binary(),
 			{
-			 PortNo :: non_neg_integer(), % TODO I'm sure there's an inet type() to use
+			 PortNo :: inet:port_number(),
 			 NodeType :: 72 | 77,
 			 Protocol :: non_neg_integer(),
 			 HighestVersion :: non_neg_integer(),
 			 LowestVersion :: non_neg_integer(),
 			 Extra :: binary()
 			},
-			Fd :: inet:socket(), %% TODO Check this type I can never remember the correct thing
+			Fd :: inet:socket(),
 			Creation :: non_neg_integer(),
 			State :: any()) ->
 	ok
@@ -22,7 +22,7 @@
 	| {error, Reason :: term()}.
 
 -callback node_port(NodeName :: binary(), State :: any()) ->
-	{ok, PortNo :: non_neg_integer()}
+	{ok, PortNo :: inet:port_number()}
 	| {error, Reason :: term()}.
 
 -callback names(State :: any()) ->
@@ -30,7 +30,7 @@
 	| {error, Reason :: term()}.
 
 -callback dump(NodeType :: 72 | 77 | all, State :: any()) ->
-	{ok, list({Name :: binary(), Port :: non_neg_integer(), Fd :: inet:socket()})}
+	{ok, list({Name :: binary(), Port :: inet:port_number(), Fd :: inet:socket()})}
 	| {error, Reason :: term()}.
 
 -callback node_stopped(Fd :: inet:socket(), State :: any()) ->

--- a/src/erlpmd_store.erl
+++ b/src/erlpmd_store.erl
@@ -1,6 +1,6 @@
 -module(erlpmd_store).
 
--callback init() -> {ok, State :: any()}
+-callback init(Args :: list(any()) ) -> {ok, State :: any()}
                     | {error, Reason :: term()}.
 
 -callback register_node(

--- a/src/erlpmd_store.erl
+++ b/src/erlpmd_store.erl
@@ -1,0 +1,42 @@
+-module(erlpmd_store).
+
+-callback init() -> {ok, State :: any()}
+                    | {error, Reason :: term()}.
+
+-callback register_node(
+            NodeName :: binary(),
+            {
+             PortNo :: non_neg_integer(), % TODO I'm sure there's an inet type() to use
+             NodeType :: 72 | 77,
+             Protocol :: non_neg_integer(),
+             HighestVersion :: non_neg_integer(),
+             LowestVersion :: non_neg_integer(),
+             Extra :: binary()
+            },
+            Fd :: inet:socket(), %% TODO Check this type I can never remember the correct thing
+            Creation :: non_neg_integer(),
+            State :: any()) ->
+    ok
+    | {error, registered}
+    | {error, Reason :: term()}.
+
+-callback node_port(NodeName :: binary(), State :: any()) ->
+    {ok, PortNo :: non_neg_integer()}
+    | {error, Reason :: term()}.
+
+-callback names(State :: any()) ->
+    {ok, Names :: list(binary())}
+    | {error, Reason :: term()}.
+
+%% TODO Maybe this should give back the structured data and let erlpmd take care of the structure->binary conv?
+-callback dump(NodeType :: 72 | 77, State :: any()) ->
+    {ok, list()}
+    | {error, Reason :: term()}.
+
+-callback node_stopped(Fd :: inet:socket(), State :: any()) ->
+    ok | {error, Reason :: term()}.
+
+-callback remove_node(NodeName :: binary(), State :: any()) ->
+    ok | {error, Reason :: term()}.
+
+%% TODO While it doesn't require any work for erlpmd_ets, maybe we need a callback for KILL_REQ?

--- a/src/erlpmd_store.erl
+++ b/src/erlpmd_store.erl
@@ -17,6 +17,7 @@
             Creation :: non_neg_integer(),
             State :: any()) ->
     ok
+    | {ok, State1 :: any()}
     | {error, registered}
     | {error, Reason :: term()}.
 
@@ -34,9 +35,13 @@
     | {error, Reason :: term()}.
 
 -callback node_stopped(Fd :: inet:socket(), State :: any()) ->
-    ok | {error, Reason :: term()}.
+    ok
+    | {ok, State1 :: any()}
+    | {error, Reason :: term()}.
 
 -callback remove_node(NodeName :: binary(), State :: any()) ->
-    ok | {error, Reason :: term()}.
+    ok
+    | {ok, State1 :: any()}
+    | {error, Reason :: term()}.
 
 %% TODO While it doesn't require any work for erlpmd_ets, maybe we need a callback for KILL_REQ?

--- a/src/erlpmd_store.erl
+++ b/src/erlpmd_store.erl
@@ -29,9 +29,8 @@
 	{ok, Names :: list(binary())}
 	| {error, Reason :: term()}.
 
-%% TODO Maybe this should give back the structured data and let erlpmd take care of the structure->binary conv?
--callback dump(NodeType :: 72 | 77, State :: any()) ->
-	{ok, list()}
+-callback dump(NodeType :: 72 | 77 | all, State :: any()) ->
+	{ok, list({Name :: binary(), Port :: non_neg_integer(), Fd :: inet:socket()})}
 	| {error, Reason :: term()}.
 
 -callback node_stopped(Fd :: inet:socket(), State :: any()) ->

--- a/src/erlpmd_store.erl
+++ b/src/erlpmd_store.erl
@@ -1,5 +1,7 @@
 -module(erlpmd_store).
 
+-include("erlpmd.hrl").
+
 -callback init(Args :: list(any()) ) -> {ok, State :: any()}
 					| {error, Reason :: term()}.
 
@@ -7,7 +9,7 @@
 			NodeName :: binary(),
 			{
 			 PortNo :: inet:port_number(),
-			 NodeType :: 72 | 77,
+			 NodeType :: ?NORMAL_NODE | ?HIDDEN_NODE,
 			 Protocol :: non_neg_integer(),
 			 HighestVersion :: non_neg_integer(),
 			 LowestVersion :: non_neg_integer(),
@@ -25,11 +27,11 @@
 	{ok, PortNo :: inet:port_number()}
 	| {error, Reason :: term()}.
 
--callback names(State :: any()) ->
+-callback names(Type :: ?NORMAL_NODE | ?HIDDEN_NODE, State :: any()) ->
 	{ok, Names :: list(binary())}
 	| {error, Reason :: term()}.
 
--callback dump(NodeType :: 72 | 77 | all, State :: any()) ->
+-callback dump(NodeType :: ?NORMAL_NODE | ?HIDDEN_NODE | all, State :: any()) ->
 	{ok, list({Name :: binary(), Port :: inet:port_number(), Fd :: inet:socket()})}
 	| {error, Reason :: term()}.
 

--- a/src/erlpmd_store.erl
+++ b/src/erlpmd_store.erl
@@ -1,47 +1,47 @@
 -module(erlpmd_store).
 
 -callback init(Args :: list(any()) ) -> {ok, State :: any()}
-                    | {error, Reason :: term()}.
+					| {error, Reason :: term()}.
 
 -callback register_node(
-            NodeName :: binary(),
-            {
-             PortNo :: non_neg_integer(), % TODO I'm sure there's an inet type() to use
-             NodeType :: 72 | 77,
-             Protocol :: non_neg_integer(),
-             HighestVersion :: non_neg_integer(),
-             LowestVersion :: non_neg_integer(),
-             Extra :: binary()
-            },
-            Fd :: inet:socket(), %% TODO Check this type I can never remember the correct thing
-            Creation :: non_neg_integer(),
-            State :: any()) ->
-    ok
-    | {ok, State1 :: any()}
-    | {error, registered}
-    | {error, Reason :: term()}.
+			NodeName :: binary(),
+			{
+			 PortNo :: non_neg_integer(), % TODO I'm sure there's an inet type() to use
+			 NodeType :: 72 | 77,
+			 Protocol :: non_neg_integer(),
+			 HighestVersion :: non_neg_integer(),
+			 LowestVersion :: non_neg_integer(),
+			 Extra :: binary()
+			},
+			Fd :: inet:socket(), %% TODO Check this type I can never remember the correct thing
+			Creation :: non_neg_integer(),
+			State :: any()) ->
+	ok
+	| {ok, State1 :: any()}
+	| {error, registered}
+	| {error, Reason :: term()}.
 
 -callback node_port(NodeName :: binary(), State :: any()) ->
-    {ok, PortNo :: non_neg_integer()}
-    | {error, Reason :: term()}.
+	{ok, PortNo :: non_neg_integer()}
+	| {error, Reason :: term()}.
 
 -callback names(State :: any()) ->
-    {ok, Names :: list(binary())}
-    | {error, Reason :: term()}.
+	{ok, Names :: list(binary())}
+	| {error, Reason :: term()}.
 
 %% TODO Maybe this should give back the structured data and let erlpmd take care of the structure->binary conv?
 -callback dump(NodeType :: 72 | 77, State :: any()) ->
-    {ok, list()}
-    | {error, Reason :: term()}.
+	{ok, list()}
+	| {error, Reason :: term()}.
 
 -callback node_stopped(Fd :: inet:socket(), State :: any()) ->
-    ok
-    | {ok, State1 :: any()}
-    | {error, Reason :: term()}.
+	ok
+	| {ok, State1 :: any()}
+	| {error, Reason :: term()}.
 
 -callback remove_node(NodeName :: binary(), State :: any()) ->
-    ok
-    | {ok, State1 :: any()}
-    | {error, Reason :: term()}.
+	ok
+	| {ok, State1 :: any()}
+	| {error, Reason :: term()}.
 
 %% TODO While it doesn't require any work for erlpmd_ets, maybe we need a callback for KILL_REQ?

--- a/src/erlpmd_sup.erl
+++ b/src/erlpmd_sup.erl
@@ -43,7 +43,8 @@ start_link(Ips,Port) when is_list(Ips) ->
 %% ===================================================================
 
 init([Ips,Port]) when is_list (Ips) ->
-	ErlPMD = {erlpmd, {erlpmd, start_link, [[]]}, transient, 5000, worker, [erlpmd]},
+    StoreMod = application:get_env(erlpmd, storage_module, erlpmd_ets),
+	ErlPMD = {erlpmd, {erlpmd, start_link, [[StoreMod]]}, transient, 5000, worker, [erlpmd]},
 	Listeners = [{{ip, Ip}, {erlpmd_tcp_listener, start_link, [[Ip,Port]]}, transient, 5000, worker, [erlpmd_tcp_listener]} || Ip <- Ips],
 	{ok, {{one_for_one, 5, 10}, [ErlPMD | Listeners]}}.
 

--- a/src/erlpmd_sup.erl
+++ b/src/erlpmd_sup.erl
@@ -27,6 +27,7 @@
 
 %% API
 -export([start_link/2]).
+-export([start_link/4]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -38,13 +39,29 @@
 start_link(Ips,Port) when is_list(Ips) ->
 	supervisor:start_link({local, ?MODULE}, ?MODULE, [Ips,Port]).
 
+start_link(Ips, Port, StoreMod, StoreOpts) when is_list(Ips), is_atom(StoreMod), is_list(StoreOpts) ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, [Ips, Port, StoreMod, StoreOpts]).
+
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
-init([Ips,Port]) when is_list (Ips) ->
-    StoreMod = application:get_env(erlpmd, storage_module, erlpmd_ets),
-	ErlPMD = {erlpmd, {erlpmd, start_link, [[StoreMod]]}, transient, 5000, worker, [erlpmd]},
-	Listeners = [{{ip, Ip}, {erlpmd_tcp_listener, start_link, [[Ip,Port]]}, transient, 5000, worker, [erlpmd_tcp_listener]} || Ip <- Ips],
+init([Ips,Port | Opts ]) when is_list (Ips) ->
+    [StoreMod, StoreOpts] =
+        case Opts of
+            [] ->
+                % TODO This is really unclean. No opts if you set it via appenv?
+                SMod = application:get_env(erlpmd, storage_module, erlpmd_ets),
+                [SMod, []];
+            [SMod, SOpts] when is_atom(SMod), is_list(SOpts) ->
+                Opts
+        end,
+    ErlPMD = {erlpmd,
+              {erlpmd, start_link, [[StoreMod, StoreOpts]]},
+              transient, 5000, worker, [erlpmd]},
+	Listeners = [{{ip, Ip},
+                  {erlpmd_tcp_listener, start_link, [[Ip,Port]]},
+                  transient, 5000, worker, [erlpmd_tcp_listener]}
+                 || Ip <- Ips],
 	{ok, {{one_for_one, 5, 10}, [ErlPMD | Listeners]}}.
 

--- a/src/erlpmd_sup.erl
+++ b/src/erlpmd_sup.erl
@@ -40,28 +40,28 @@ start_link(Ips,Port) when is_list(Ips) ->
 	supervisor:start_link({local, ?MODULE}, ?MODULE, [Ips,Port]).
 
 start_link(Ips, Port, StoreMod, StoreOpts) when is_list(Ips), is_atom(StoreMod), is_list(StoreOpts) ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, [Ips, Port, StoreMod, StoreOpts]).
+	supervisor:start_link({local, ?MODULE}, ?MODULE, [Ips, Port, StoreMod, StoreOpts]).
 
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
 init([Ips,Port | Opts ]) when is_list (Ips) ->
-    [StoreMod, StoreOpts] =
-        case Opts of
-            [] ->
-                % TODO This is really unclean. No opts if you set it via appenv?
-                SMod = application:get_env(erlpmd, storage_module, erlpmd_ets),
-                [SMod, []];
-            [SMod, SOpts] when is_atom(SMod), is_list(SOpts) ->
-                Opts
-        end,
-    ErlPMD = {erlpmd,
-              {erlpmd, start_link, [[StoreMod, StoreOpts]]},
-              transient, 5000, worker, [erlpmd]},
+	[StoreMod, StoreOpts] =
+		case Opts of
+			[] ->
+				% TODO This is really unclean. No opts if you set it via appenv?
+				SMod = application:get_env(erlpmd, storage_module, erlpmd_ets),
+				[SMod, []];
+			[SMod, SOpts] when is_atom(SMod), is_list(SOpts) ->
+				Opts
+		end,
+	ErlPMD = {erlpmd,
+			  {erlpmd, start_link, [[StoreMod, StoreOpts]]},
+			  transient, 5000, worker, [erlpmd]},
 	Listeners = [{{ip, Ip},
-                  {erlpmd_tcp_listener, start_link, [[Ip,Port]]},
-                  transient, 5000, worker, [erlpmd_tcp_listener]}
-                 || Ip <- Ips],
+				  {erlpmd_tcp_listener, start_link, [[Ip,Port]]},
+				  transient, 5000, worker, [erlpmd_tcp_listener]}
+				 || Ip <- Ips],
 	{ok, {{one_for_one, 5, 10}, [ErlPMD | Listeners]}}.
 

--- a/src/erlpmd_sup.erl
+++ b/src/erlpmd_sup.erl
@@ -44,6 +44,6 @@ start_link(Ips,Port) when is_list(Ips) ->
 
 init([Ips,Port]) when is_list (Ips) ->
 	ErlPMD = {erlpmd, {erlpmd, start_link, [[]]}, transient, 5000, worker, [erlpmd]},
-	Listeners = [{{ip, Ip}, {tcp_listener, start_link, [[Ip,Port]]}, transient, 5000, worker, [tcp_listener]} || Ip <- Ips],
+	Listeners = [{{ip, Ip}, {erlpmd_tcp_listener, start_link, [[Ip,Port]]}, transient, 5000, worker, [erlpmd_tcp_listener]} || Ip <- Ips],
 	{ok, {{one_for_one, 5, 10}, [ErlPMD | Listeners]}}.
 

--- a/src/erlpmd_tcp_listener.erl
+++ b/src/erlpmd_tcp_listener.erl
@@ -21,7 +21,7 @@
 %% THE SOFTWARE.
 %%
 
--module(tcp_listener).
+-module(erlpmd_tcp_listener).
 
 -behaviour(gen_server).
 


### PR DESCRIPTION
- Separate the ETS-backed storage from the `erl_epmd` process (as `erlpmd_ets` module), via `erlpmd_store` behaviour
- Allow passing which `erlpmd_store` implementation module to use via `erlpmd_sup:start_link/2,4`
- Rename `tcp_listener` to `erlpmd_tcp_listener`
- (Support for Erlangs older than 17.4) Don't try to `-include_lib('kernel/src/erl_epmd.hrl')`, nor use the `?EPMD_NAMES` et al macros it defines.
